### PR TITLE
libretro: Fix crash with no content.

### DIFF
--- a/src/platform/libretro/main.cpp
+++ b/src/platform/libretro/main.cpp
@@ -139,8 +139,6 @@ void retro_set_environment(retro_environment_t cb)
       { NULL, NULL },
    };
 
-   bool no_rom = true;
-   cb(RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME, &no_rom);
    cb(RETRO_ENVIRONMENT_SET_VARIABLES, variables);
 }
 


### PR DESCRIPTION
Fixes the following crash when running the core without content.
```
hread 1 "retroarch" received signal SIGSEGV, Segmentation fault.
0x00007fffe8ed3b24 in retro_load_game (info=0x0) at main.cpp:475
475    strcpy(levelpath, info->path);
(gdb) bt
#0  0x00007fffe8ed3b24 in retro_load_game (info=0x0) at main.cpp:475
#1  0x0000000000415833 in core_load_game (load_info=0x7fffffffd810) at core_impl.c:291
#2  0x000000000042d74f in content_file_load (info=0x167c9d0, content=0x1689910, content_ctx=0x7fffffffd8e0, error_string=0x7fffffffd8d8,
    special=0x0, additional_path_allocs=0x1689b40) at tasks/task_content.c:608
#3  0x000000000042dcf9 in content_file_init (content_ctx=0x7fffffffd8e0, content=0x1689910, error_string=0x7fffffffd8d8)
    at tasks/task_content.c:789
#4  0x000000000042f9cd in content_init () at tasks/task_content.c:1803
#5  0x000000000041e64a in event_init_content () at command.c:1227
#6  0x000000000041e79b in command_event_init_core (data=0xd18788 <current_core_type>) at command.c:1285
#7  0x0000000000420215 in command_event (cmd=CMD_EVENT_CORE_INIT, data=0xd18788 <current_core_type>) at command.c:2242
#8  0x0000000000417c3b in retroarch_main_init (argc=3, argv=0x7fffffffe1b8) at retroarch.c:1278
#9  0x000000000042cdd4 in content_load (info=0x7fffffffe080) at tasks/task_content.c:270
#10 0x000000000042df08 in task_load_content (content_info=0x7fffffffe080, content_ctx=0x7fffffffdfa0, launched_from_menu=true,
    launched_from_cli=true, error_string=0x7fffffffdf98) at tasks/task_content.c:856
#11 0x000000000042f31c in task_load_content_callback (content_info=0x7fffffffe080, loading_from_menu=true, loading_from_cli=true)
    at tasks/task_content.c:1534
#12 0x000000000042f491 in task_push_load_content_from_cli (core_path=0x0, fullpath=0x0, content_info=0x7fffffffe080, type=CORE_TYPE_PLAIN, cb=0x0,
    user_data=0x0) at tasks/task_content.c:1598
#13 0x000000000041466b in rarch_main (argc=3, argv=0x7fffffffe1b8, data=0x0) at frontend/frontend.c:115
#14 0x00000000004146ee in main (argc=3, argv=0x7fffffffe1b8) at frontend/frontend.c:151
```
Full GDB log - https://pastebin.com/2ZH1g8Bb

My understanding is that this core requires content and these two lines are telling RetroArch that it does not require content where it will then crash when RetroArch considers it an contentless core in `core_impl.c`.

@alcaro and @twinaphex Can you please review this and make sure this is right?