### PR TITLE
Fix Android compilation

### DIFF
--- a/src/platform/libretro/jni/Android.mk
+++ b/src/platform/libretro/jni/Android.mk
@@ -2,9 +2,8 @@ LOCAL_PATH := $(call my-dir)
 
 CORE_DIR := $(LOCAL_PATH)/..
 
-# Force gles2 for now since gles3 doesn't compile
 GLES  := 1
-GLES3 := 0
+GLES3 := 1
 
 include $(CORE_DIR)/Makefile.common
 

--- a/src/platform/libretro/jni/Application.mk
+++ b/src/platform/libretro/jni/Application.mk
@@ -1,7 +1,3 @@
 APP_ABI := all
-ifeq ($(GLES), 3)
-   APP_PLATFORM := android-18
-else
-   APP_PLATFORM := android-9
-endif
+APP_PLATFORM := android-18
 


### PR DESCRIPTION
Despite what the comments say Openlara uses
functions available only in glesv3. Hence we need to
force GLES3 and not GLES2. Then we need to fix compile error.
It was due to requiring too low version of Android before it
had GLESv3