### PR TITLE
Makefile fix to enable build for "unix-armv7-hardfloat-neon"

### DIFF
--- a/src/platform/libretro/Makefile
+++ b/src/platform/libretro/Makefile
@@ -100,12 +100,13 @@ else ifneq (,$(findstring qnx,$(platform)))
    GL_LIB := -lGLESv2
    GLES := 1
 else ifneq (,$(findstring armv,$(platform)))
-   CC = gcc
+   CC ?= gcc
    TARGET := $(TARGET_NAME)_libretro.so
    fpic := -fPIC
    SHARED := -shared -Wl,--version-script=link.T -Wl,--no-undefined
    CXXFLAGS += -I.
    CFLAGS += -I.
+   LIBS += -lpthread
 ifneq (,$(findstring gles,$(platform)))
    GLES := 1
 else


### PR DESCRIPTION
"armv" platform is recognized by the makefile, but actual compilation was not successful for "unix-armv7-hardfloat-neon" (one of the options in libretro-super build scripts).

Added missing definition from "unix" platform. Since this file is not present in the upstream repo, it does not add to conflicts.
