### PR TITLE
Fix compiling on 64bit Windows

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,10 @@
 # Inclusion templates, required for the build to work
 include:
   ################################## DESKTOPS ################################  
+  # Windows 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/windows-x64-mingw.yml'
+
   # Linux 64-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-x64.yml'
@@ -41,6 +45,12 @@ stages:
 ##############################################################################
 #
 ################################### DESKTOPS #################################
+# Windows 64-bit
+libretro-build-windows-x64:
+  extends:
+    - .libretro-windows-x64-mingw-make-default
+    - .core-defs
+
 # Linux 64-bit
 libretro-build-linux-x64:
   extends:

--- a/src/platform/libretro/glsym.h
+++ b/src/platform/libretro/glsym.h
@@ -1,0 +1,38 @@
+/* Copyright (C) 2010-2018 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this libretro SDK code part (glsym).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef __LIBRETRO_SDK_GLSYM_H__
+#define __LIBRETRO_SDK_GLSYM_H__
+
+#include <glsym/rglgen.h>
+
+#ifndef HAVE_PSGL
+#if defined(HAVE_OPENGLES2)
+#include <glsym/glsym_es2.h>
+#elif defined(HAVE_OPENGLES3)
+#include <glsym/glsym_es3.h>
+#else
+#endif
+#endif
+
+#endif
+

--- a/src/platform/libretro/main.cpp
+++ b/src/platform/libretro/main.cpp
@@ -4,7 +4,12 @@
 #include <string.h>
 #include <math.h>
 
+#ifdef _WIN32
+#include "glsym.h" // Use local modified glsym.h to allow compilation on 64bit Windows
+#else
 #include <glsym/glsym.h>
+#endif
+
 #include <libretro.h>
 #include <file/file_path.h>
 


### PR DESCRIPTION
This fixes compiling OpenLara for Windows with MingW64.
Tried getting it to compile with MingW32 as well for 32bit Windows systems, but not only would it not detect the #ifdef _WIN32, it also threw out like 20 odd "undefined reference to `os[GetTime()/MutexLock(void*)/MutexUnlock(void*)/MutexFree(void*)]" linker errors.