### PR TITLE
libretro: fix windows (mingw) and android build

### DIFF
--- a/src/gapi/gl.h
+++ b/src/gapi/gl.h
@@ -13,9 +13,9 @@ extern struct retro_hw_render_callback hw_render;
 #endif
 
 #ifdef _OS_WIN
-    #include <gl/GL.h>
-    #include <gl/glext.h>
-    #include <gl/wglext.h>
+    #include <GL/gl.h>
+    #include <GL/glext.h>
+    #include <GL/wglext.h>
 #elif __LIBRETRO_GLES__
     #include <EGL/egl.h>
     #include <GLES2/gl2.h>
@@ -463,19 +463,31 @@ extern struct retro_hw_render_callback hw_render;
         PFNGLBUFFERSUBDATAARBPROC           glBufferSubData;
     #endif
 
-#ifndef __LIBRETRO__
 // Vertex Arrays
-    PFNGLGENVERTEXARRAYSPROC            glGenVertexArrays;
-    PFNGLDELETEVERTEXARRAYSPROC         glDeleteVertexArrays;
-    PFNGLBINDVERTEXARRAYPROC            glBindVertexArray;
+    #ifndef glGenVertexArrays
+        PFNGLGENVERTEXARRAYSPROC glGenVertexArrays;
+    #endif
+
+    #ifndef glDeleteVertexArrays
+        PFNGLDELETEVERTEXARRAYSPROC glDeleteVertexArrays;
+    #endif
+
+    #ifndef glBindVertexArray
+        PFNGLBINDVERTEXARRAYPROC glBindVertexArray;
+    #endif
+
 // Binary shaders
-    PFNGLGETPROGRAMBINARYPROC           glGetProgramBinary;
-    PFNGLPROGRAMBINARYPROC              glProgramBinary;
+    #ifndef glGetProgramBinary
+        PFNGLGETPROGRAMBINARYPROC glGetProgramBinary;
+    #endif
+
+    #ifndef glProgramBinary
+        PFNGLPROGRAMBINARYPROC glProgramBinary;
+    #endif
 
     #if defined(_GAPI_GLES)
         PFNGLDISCARDFRAMEBUFFEREXTPROC      glDiscardFramebufferEXT;
     #endif
-#endif
 
 #endif
 
@@ -1278,7 +1290,7 @@ namespace GAPI {
             #endif
 #endif
 
-            #if defined(_OS_WIN) || defined(_OS_LINUX) && !(__LIBRETRO_GLES__) || (defined(__SDL2__) && (defined(_GAPI_GLES2) || defined(_SDL2_OPENGL)))
+            #if defined(_OS_WIN) || defined(_OS_LINUX) && !(__LIBRETRO__) || (defined(__SDL2__) && (defined(_GAPI_GLES2) || defined(_SDL2_OPENGL)))
                 GetProcOGL(glGenerateMipmap);
                 #ifdef _OS_WIN
                     GetProcOGL(glTexImage3D);

--- a/src/platform/libretro/Makefile
+++ b/src/platform/libretro/Makefile
@@ -15,6 +15,10 @@ ifeq ($(platform),)
 	else ifneq ($(findstring win,$(shell uname -a)),)
 		platform = win
 	endif
+   # cross compilation to windows from unix
+   ifneq (,$(findstring mingw,$(CC)))
+      platform = win
+   endif
 endif
 
 # system platform
@@ -140,12 +144,13 @@ endif
 else ifeq ($(platform), emscripten)
 	TARGET := $(TARGET_NAME)_libretro_emscripten.bc
 else
+# windows
    CC ?= gcc
    TARGET := $(TARGET_NAME)_libretro.dll
    SHARED := -shared -static-libgcc -static-libstdc++ -Wl,--version-script=link.T -lwinmm -Wl,--no-undefined
    GL_LIB := -lopengl32
-   CXXFLAGS += -I..
-   CFLAGS += -I..
+   CXXFLAGS += -I.. -DWIN32
+   CFLAGS += -I.. -DWIN32
 endif
 
 # webOS

--- a/src/platform/libretro/Makefile.common
+++ b/src/platform/libretro/Makefile.common
@@ -12,6 +12,7 @@ SOURCES_C   := $(LIBRETRO_COMM_DIR)/glsym/rglgen.c \
 					$(LIBS_DIR)/tinf/tinflate.c \
 					$(LIBRETRO_COMM_DIR)/compat/compat_strl.c \
 					$(LIBRETRO_COMM_DIR)/compat/compat_strcasestr.c \
+					$(LIBRETRO_COMM_DIR)/compat/fopen_utf8.c \
 					$(LIBRETRO_COMM_DIR)/file/file_path.c \
 					$(LIBRETRO_COMM_DIR)/file/file_path_io.c \
 					$(LIBRETRO_COMM_DIR)/encodings/encoding_utf.c \


### PR DESCRIPTION
Fixes building for those platforms.

Compiles fine.

Briefly tested running and jumping on Windows 11 and Android