### PR TITLE
Fix glvnd build

### DIFF
--- a/src/gapi/gl.h
+++ b/src/gapi/gl.h
@@ -300,7 +300,12 @@ extern struct retro_hw_render_callback hw_render;
 #elif _OS_LINUX && !defined(__LIBRETRO_GLES__)
     #include <GL/gl.h>
     #include <GL/glext.h>
+#if defined(USE_GLVND) // Modern GL on GNU/Linux is GLVND, and it uses EGL instead of GLX.
+    #include <EGL/egl.h>
+    extern EGLDisplay display;
+#else
     #include <GL/glx.h>
+#endif
 #elif __APPLE__
     #ifdef _OS_IOS
         #include <OpenGLES/ES2/gl.h>
@@ -376,7 +381,11 @@ extern struct retro_hw_render_callback hw_render;
         #ifdef _OS_WIN
             return (void*)wglGetProcAddress(name);
         #elif _OS_LINUX && !(__LIBRETRO_GLES__)
+            #if defined(USE_GLVND)
+            return (void*)eglGetProcAddress(name);
+            #else
             return (void*)glXGetProcAddress((GLubyte*)name);
+            #endif
         #elif __SDL2__
             return (void*)SDL_GL_GetProcAddress(name);
         #else // EGL
@@ -397,7 +406,7 @@ extern struct retro_hw_render_callback hw_render;
     #ifdef _OS_WIN
         typedef BOOL (WINAPI * PFNWGLSWAPINTERVALEXTPROC) (int interval);
         PFNWGLSWAPINTERVALEXTPROC wglSwapIntervalEXT;
-    #elif _OS_LINUX
+    #elif _OS_LINUX && !defined(USE_GLVND)
         typedef int (*PFNGLXSWAPINTERVALSGIPROC) (int interval);
         PFNGLXSWAPINTERVALSGIPROC glXSwapIntervalSGI;
     #endif
@@ -1693,7 +1702,11 @@ namespace GAPI {
         #ifdef _OS_WIN
             if (wglSwapIntervalEXT) wglSwapIntervalEXT(enable ? 1 : 0);
         #elif _OS_LINUX
+            #if defined(USE_GLVND)
+            eglSwapInterval(display, enable ? 1 : 0);
+            #else
             if (glXSwapIntervalSGI) glXSwapIntervalSGI(enable ? 1 : 0);
+            #endif
         #elif defined(__SDL2__)
             SDL_GL_SetSwapInterval(enable ? 1 : 0);
         #elif defined(_OS_RPI) || defined(_OS_CLOVER) || defined(_OS_SWITCH)

--- a/src/platform/libretro/Makefile
+++ b/src/platform/libretro/Makefile
@@ -41,7 +41,7 @@ ifeq ($(platform), unix)
    fpic := -fPIC
    SHARED := -shared -Wl,--version-script=link.T -Wl,--no-undefined
    ##MACMAC
-   ifeq ($(USE_GLVND), 1)
+   ifeq ($(GLVND), 1)
    GL_LIB := -lOpenGL
    LIBS += -lEGL
    CXXFLAGS += -DUSE_GLVND

--- a/src/platform/libretro/Makefile
+++ b/src/platform/libretro/Makefile
@@ -40,7 +40,16 @@ ifeq ($(platform), unix)
    TARGET := $(TARGET_NAME)_libretro.so
    fpic := -fPIC
    SHARED := -shared -Wl,--version-script=link.T -Wl,--no-undefined
+   ##MACMAC
+   ifeq ($(USE_GLVND), 1)
+   GL_LIB := -lOpenGL
+   LIBS += -lEGL
+   CXXFLAGS += -DUSE_GLVND
+   CFLAGS += -DUSE_GLVND
+   else
    GL_LIB := -lGL
+   endif
+   ##MACMAC
    LIBS += -lpthread
    CFLAGS += -D_GNU_SOURCE
    CXXFLAGS += -D_GNU_SOURCE

--- a/src/platform/libretro/main.cpp
+++ b/src/platform/libretro/main.cpp
@@ -62,6 +62,10 @@ static retro_input_poll_t input_poll_cb;
 static retro_input_state_t input_cb;
 static retro_set_rumble_state_t set_rumble_cb;
 
+#ifdef USE_GLVND
+EGLDisplay display;
+#endif
+
 #ifdef _WIN32
 #include <windows.h>
 #include <mmsystem.h>


### PR DESCRIPTION
Modern OpenGL implementation on GNU/Linux is GLVND, not GLX which was an X11 only thing.
Consequently, I added an option (GLVND) that can be passed to `make` to build this core against modern GLVND instead of legacy X11-only GLX.