### PR TITLE
Windows path fix when launching from RetroArch GUI

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -33,7 +33,7 @@
     #endif
 
     #undef OS_PTHREAD_MT
-#elif WIN32
+#elif defined(_WIN32)
     #define _OS_WIN      1
     #define _GAPI_GL     1
     //#define _GAPI_D3D9   1
@@ -53,7 +53,7 @@
 
     #define INV_VIBRATION
     #define INV_QUALITY
-#elif ANDROID
+#elif defined(ANDROID)
     #define _OS_ANDROID 1
     #define _GAPI_GL    1
     #define _GAPI_GLES  1

--- a/src/platform/libretro/main.cpp
+++ b/src/platform/libretro/main.cpp
@@ -668,7 +668,9 @@ bool retro_load_game(const struct retro_game_info *info)
    path_parent_dir(contentDir, strlen(contentDir));
    fill_pathname_parent_dir_name(basedir, contentDir, sizeof(basedir));
 
-   if (strcmp(basedir, "level") == 0 || strstr(contentDir, "/level") != NULL)
+   if (strcmp(basedir, "level") == 0
+    || strstr(contentDir, "/level") != NULL
+    || strstr(contentDir, "\\level") != NULL)
    {
       // level/X/
       path_parent_dir(contentDir, strlen(contentDir));
@@ -678,6 +680,12 @@ bool retro_load_game(const struct retro_game_info *info)
 
    // make levelpath contain a path relative to contentDir
    strcpy(levelpath, (info->path+strlen(contentDir)));
+
+#ifdef _WIN32
+   /* Normalize backslashes to forward slashes for OpenLara's path handling */
+   for (char *p = levelpath; *p; p++)
+      if (*p == '\\') *p = '/';
+#endif
 
    fprintf(stderr, "[openlara]: levelpath: %s\n", levelpath);
 


### PR DESCRIPTION
Content wasn't loading correctly when launching from the GUI (it worked fine from terminal).