### PR TITLE
Fix GL shaders being used for GLES 2, also fix GLES 3 compile

### DIFF
--- a/src/gapi/gl.h
+++ b/src/gapi/gl.h
@@ -485,7 +485,7 @@ extern struct retro_hw_render_callback hw_render;
         PFNGLPROGRAMBINARYPROC glProgramBinary;
     #endif
 
-    #if defined(_GAPI_GLES)
+    #if defined(_GAPI_GLES) && !(__LIBRETRO__)
         PFNGLDISCARDFRAMEBUFFEREXTPROC      glDiscardFramebufferEXT;
     #endif
 
@@ -1492,7 +1492,7 @@ namespace GAPI {
             }
         }
         
-    #ifdef _GAPI_GLES
+    #if defined(_GAPI_GLES) || defined(_GAPI_GLES2)
         if (GLES3) {
             // vertex
             strcat(GLSL_HEADER_VERT, "#version 300 es\n"


### PR DESCRIPTION
When using GLES 2 it will try to use desktop GL shaders causing a runtime failure.

When compiling with GLES 3, it also fixes this issue:

``` multiple definition of `__rglgen_glDiscardFramebufferEXT'; ./libretro-common/glsym/glsym_es3.o:(.bss+0x390): first defined here
collect2: error: ld returned 1 exit status
make: *** [Makefile:229: openlara_libretro.so] Error 1
```
